### PR TITLE
Create 삼총사.java

### DIFF
--- a/KHJ_Root/백준문제/삼총사.java
+++ b/KHJ_Root/백준문제/삼총사.java
@@ -1,0 +1,19 @@
+class Solution {
+    public int solution(int[] number) {
+        int n = number.length;
+        int count = 0;
+        
+        // 세 학생의 인덱스 i, j, k 선택 (i < j < k)
+        for (int i = 0; i < n - 2; i++) {
+            for (int j = i + 1; j < n - 1; j++) {
+                for (int k = j + 1; k < n; k++) {
+                    if (number[i] + number[j] + number[k] == 0) {
+                        count++;
+                    }
+                }
+            }
+        }
+        
+        return count;
+    }
+}


### PR DESCRIPTION
순열 조합 문제로 보입니다. 순서가 중요하지 않으므로 (a, b , c) 와 (a, c, b)는 동일합니다. 배열길이 nn < 13, 3개를 선택하는 조합수는 최대 286. 완전탐색 또한 무리 없기에 3중 루프를 사용했습니다. 재귀풀이보다 오히려 직관적이라 생각합니다.